### PR TITLE
Per-user chat message notifications

### DIFF
--- a/integration-testing/utils/fragments.js
+++ b/integration-testing/utils/fragments.js
@@ -44,6 +44,7 @@ module.exports.chatMessage = gql`
 
 module.exports.chatMessageNotification = gql`
   fragment ChatMessageNotificationFragment on ChatMessageNotification {
+    userId
     messageId
     chatId
     authorUserId

--- a/integration-testing/utils/schema.js
+++ b/integration-testing/utils/schema.js
@@ -1189,8 +1189,8 @@ module.exports.triggerChatMessageNotification = gql`
 `
 
 module.exports.onChatMessageNotification = gql`
-  subscription OnChatMessageNotification ($chatId: ID!) {
-    onChatMessageNotification (chatId: $chatId) {
+  subscription OnChatMessageNotification ($userId: ID!) {
+    onChatMessageNotification (userId: $userId) {
       ...ChatMessageNotificationFragment
     }
   }

--- a/real-main/app/models/chat_message/manager.py
+++ b/real-main/app/models/chat_message/manager.py
@@ -71,7 +71,7 @@ class ChatMessageManager:
         text = f'@{user.username} created the group'
         if name:
             text += f' "{name}"'
-        return self.add_system_message(chat_id, text, now=now)
+        return self.add_system_message(chat_id, text, user_ids=[created_by_user_id], now=now)
 
     def add_system_message_added_to_group(self, chat_id, added_by_user_id, users, now=None):
         assert users, 'No system message should be sent if no users added to group'
@@ -82,7 +82,7 @@ class ChatMessageManager:
             text += ', '.join(f'@{u.username}' for u in users)
             text += ' and '
         text += f'@{user_1.username} to the group'
-        return self.add_system_message(chat_id, text, now=now)
+        return self.add_system_message(chat_id, text, user_ids=[u.id for u in users], now=now)
 
     def add_system_message_left_group(self, chat_id, user_id):
         user = self.user_manager.get_user(user_id)
@@ -98,9 +98,9 @@ class ChatMessageManager:
             text += 'deleted the name of the group'
         return self.add_system_message(chat_id, text)
 
-    def add_system_message(self, chat_id, text, now=None):
+    def add_system_message(self, chat_id, text, user_ids=None, now=None):
         user_id = None
         message_id = str(uuid.uuid4())
         message = self.add_chat_message(message_id, text, chat_id, user_id, now=now)
-        message.trigger_notification(message.enums.ChatMessageNotificationType.ADDED)
+        message.trigger_notifications(message.enums.ChatMessageNotificationType.ADDED, user_ids=user_ids)
         return message

--- a/real-main/app_tests/models/chat_message/test_model.py
+++ b/real-main/app_tests/models/chat_message/test_model.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, call
+from unittest.mock import call
 
 import pendulum
 import pytest
@@ -15,6 +15,11 @@ def user1(user_manager):
 @pytest.fixture
 def user2(user_manager):
     yield user_manager.create_cognito_only_user('pbuid2', 'pbUname2')
+
+
+@pytest.fixture
+def user3(user_manager):
+    yield user_manager.create_cognito_only_user('pbuid3', 'pbUname3')
 
 
 @pytest.fixture
@@ -107,20 +112,89 @@ def test_chat_message_delete(message, chat, user1, user2):
     assert pendulum.parse(chat.dynamo.get_chat_membership(chat.id, user2.id)['gsiK2SortKey'][len('chat/'):]) == now
 
 
-def test_chat_message_trigger_notification(message, chat, user1):
+def test_trigger_notifications_direct(message, chat, user1, user2, appsync_client):
     # trigger a notificaiton and check our mock client was called as expected
-    message.appsync_client = Mock()
-    message.trigger_notification('ntype')
-    expected_input = {
-        'messageId': 'mid',
-        'chatId': chat.id,
-        'authorUserId': user1.id,
-        'type': 'ntype',
-        'text': 'lore ipsum',
-        'textTaggedUserIds': [],
-        'createdAt': message.item['createdAt'],
-        'lastEditedAt': None
-    }
-    message.appsync_client.mock_calls == [
-        call.send(message.trigger_notification_mutation, {'input': expected_input})
+    message.trigger_notifications('ntype')
+    appsync_client.mock_calls == [
+        call.send(message.trigger_notification_mutation, {'input': {
+            'userId': user2.id,
+            'messageId': message.id,
+            'chatId': chat.id,
+            'authorUserId': user1.id,
+            'type': 'ntype',
+            'text': message.item['text'],
+            'textTaggedUserIds': [],
+            'createdAt': message.item['createdAt'],
+            'lastEditedAt': None
+        }})
     ]
+
+
+def test_trigger_notifications_user_ids(message, chat, user1, user2, user3, appsync_client):
+    # trigger a notification and check that we can use user_ids param to push
+    # the notifications to users that aren't found in dynamo
+    message.trigger_notifications('ntype', user_ids=[user2.id, user3.id])
+    assert len(appsync_client.mock_calls) == 2
+    sent_to_user_ids = []
+    for call_args in appsync_client.send.call_args_list:
+        assert call_args.args[0] == message.trigger_notification_mutation
+        assert list(call_args.args[1].keys()) == ['input']
+        assert call_args.args[1]['input']['messageId'] == 'mid'
+        assert call_args.args[1]['input']['chatId'] == chat.id
+        assert call_args.args[1]['input']['authorUserId'] == user1.id
+        assert call_args.args[1]['input']['type'] == 'ntype'
+        assert call_args.args[1]['input']['text'] == message.item['text']
+        assert call_args.args[1]['input']['textTaggedUserIds'] == []
+        assert call_args.args[1]['input']['createdAt'] == message.item['createdAt']
+        assert call_args.args[1]['input']['lastEditedAt'] is None
+        sent_to_user_ids.append(call_args.args[1]['input']['userId'])
+    # order of triggering isn't guaranteed
+    assert sorted(sent_to_user_ids) == sorted([user2.id, user3.id])
+
+
+def test_trigger_notifications_group(chat_manager, chat_message_manager, user1, user2, user3, appsync_client):
+    # user1 creates a group chat with everyone in it
+    group_chat = chat_manager.add_group_chat('cid', user1.id)
+    group_chat.add(user1.id, [user2.id, user3.id])
+    appsync_client.reset_mock()
+
+    # user2 creates a message, trigger notificaitons on it
+    message_id = 'mid'
+    message = chat_message_manager.add_chat_message(message_id, 'lore', group_chat.id, user2.id)
+    message.trigger_notifications('ntype')
+    assert len(appsync_client.mock_calls) == 2
+    sent_to_user_ids = []
+    for call_args in appsync_client.send.call_args_list:
+        assert call_args.args[0] == message.trigger_notification_mutation
+        assert list(call_args.args[1].keys()) == ['input']
+        assert call_args.args[1]['input']['messageId'] == message_id
+        assert call_args.args[1]['input']['chatId'] == group_chat.id
+        assert call_args.args[1]['input']['authorUserId'] == user2.id
+        assert call_args.args[1]['input']['type'] == 'ntype'
+        assert call_args.args[1]['input']['text'] == message.item['text']
+        assert call_args.args[1]['input']['textTaggedUserIds'] == []
+        assert call_args.args[1]['input']['createdAt'] == message.item['createdAt']
+        assert call_args.args[1]['input']['lastEditedAt'] is None
+        sent_to_user_ids.append(call_args.args[1]['input']['userId'])
+    # order of triggering isn't guaranteed
+    assert sorted(sent_to_user_ids) == sorted([user1.id, user3.id])
+
+    # add system message, notifications are triggered automatically
+    appsync_client.reset_mock()
+    message = chat_message_manager.add_system_message_group_name_edited(group_chat.id, user3.id, 'cname')
+    assert len(appsync_client.send.call_args_list) == 3
+    sent_to_user_ids = []
+    for call_args in appsync_client.send.call_args_list:
+        assert call_args.args[0] == message.trigger_notification_mutation
+        assert list(call_args.args[1].keys()) == ['input']
+        assert call_args.args[1]['input']['messageId']
+        assert call_args.args[1]['input']['chatId'] == group_chat.id
+        assert call_args.args[1]['input']['authorUserId'] is None
+        assert call_args.args[1]['input']['type'] == 'ADDED'
+        assert call_args.args[1]['input']['text']
+        assert call_args.args[1]['input']['textTaggedUserIds']
+        assert call_args.args[1]['input']['createdAt']
+        assert call_args.args[1]['input']['lastEditedAt'] is None
+        sent_to_user_ids.append(call_args.args[1]['input']['userId'])
+    # order of triggering isn't guaranteed
+    assert sorted(sent_to_user_ids) == sorted([user1.id, user2.id, user3.id])

--- a/real-main/mapping-templates/Subscription.onChatMessageNotification.request.vtl
+++ b/real-main/mapping-templates/Subscription.onChatMessageNotification.request.vtl
@@ -1,11 +1,11 @@
 #set ($callerUserId = $ctx.identity.cognitoIdentityId)
-#set ($chatId = $ctx.args.chatId)
+#set ($userId = $ctx.args.userId)
+
+#if ($userId != $callerUserId)
+  $util.error('Cannot subscribe to chat messages intended for another user', 'ClientError')
+#end
 
 {
   "version": "2018-05-29",
-  "operation": "GetItem",
-  "key": {
-    "partitionKey": { "S": "chat/$chatId" },
-    "sortKey": { "S": "member/$callerUserId" }
-  }
+  "payload": $util.toJson(null)
 }

--- a/real-main/mapping-templates/Subscription.onChatMessageNotification.response.vtl
+++ b/real-main/mapping-templates/Subscription.onChatMessageNotification.response.vtl
@@ -1,9 +1,0 @@
-#if ($ctx.error)
-  $util.error($ctx.error.message, $ctx.error.type)
-#end
-
-#if ($util.isNull($ctx.result))
-  $util.error('Caller is not part of that chat', 'ClientError')
-#end
-
-$util.toJson(null)

--- a/real-main/schema.graphql
+++ b/real-main/schema.graphql
@@ -228,9 +228,11 @@ type Mutation {
 }
 
 type Subscription {
-  # Subscribe to notifications of changes to the chat messages in a given chat
-  #   - may only be called with a chatId of a chat the caller is in
-  onChatMessageNotification(chatId: ID!): ChatMessageNotification @aws_subscribe(mutations: ["triggerChatMessageNotification"])
+  # Subscribe to notifications of changes (adds, edits, and deletes) of chat messages
+  # in chats we are in or have just been added to
+  #   - userId must be caller's own userId. Required by AppSync subscription design
+  #   - does not fire for the caller's own messages
+  onChatMessageNotification(userId: ID!): ChatMessageNotification @aws_subscribe(mutations: ["triggerChatMessageNotification"])
 }
 
 type User {
@@ -388,6 +390,7 @@ type PaginatedChatMessages {
 
 # Abridged version of a ChatMessage that will be pushed to clients
 type ChatMessageNotification {
+  userId: ID!  # user this notification is intended for
   messageId: ID!
   chatId: ID!
   authorUserId: ID  # null if this is a system message (ex: 'user X left the chat')
@@ -405,6 +408,7 @@ enum ChatMessageNotificationType {
 }
 
 input ChatMessageNotificationInput {
+  userId: ID!  # user this notification is intended for
   messageId: ID!
   chatId: ID!
   authorUserId: ID  # null if this is a system message (ex: 'user X left the chat')

--- a/real-main/serverless.yml
+++ b/real-main/serverless.yml
@@ -894,7 +894,8 @@ custom:
 
       - type: Subscription
         field: onChatMessageNotification
-        dataSource: DynamodbDataSource
+        dataSource: NoneDataSource
+        response: PassThru.response.vtl
 
     functionConfigurations:
 


### PR DESCRIPTION
Requires us to to the fan-out of message notificaitons in code, rather
than relying on appsync's subscription mechanisms.

This implementation of that fan out won't scale to huge group chats
(should be fine up to 100 or so users), but when we get up to larger
chats we will need to be smarter about how we sent notifications to
users.