### PR TITLE
Allow anonymous user to report screen views

### DIFF
--- a/integration-testing/tests/screen-view.test.js
+++ b/integration-testing/tests/screen-view.test.js
@@ -1,6 +1,7 @@
 const cognito = require('../utils/cognito')
 const {mutations} = require('../schema')
 
+let anonClient
 const loginCache = new cognito.AppSyncLoginCache()
 jest.retryTimes(1)
 
@@ -31,5 +32,32 @@ test('Report views of some screens', async () => {
   // verify reporting over 100 screens is an error
   await expect(
     client.mutate({mutation: mutations.reportScreenViews, variables: {screens: Array(101).fill('arbitrary')}}),
+  ).rejects.toThrow(/ClientError: A max of 100 screens /)
+})
+
+test('Anonymous user can report views of some screens', async () => {
+  ;({client: anonClient} = await cognito.getAnonymousAppSyncLogin())
+
+  // verify reporting no screens is an error
+  await expect(
+    anonClient.mutate({mutation: mutations.reportScreenViews, variables: {screens: []}}),
+  ).rejects.toThrow(/ClientError: A minimum of 1 screen /)
+
+  // verify we can report one screen
+  await anonClient
+    .mutate({mutation: mutations.reportScreenViews, variables: {screens: ['arbitrary']}})
+    .then(({data: {reportScreenViews}}) => expect(reportScreenViews).toBe(true))
+
+  // verify we can report three screens, including duplicates are ok
+  await anonClient
+    .mutate({mutation: mutations.reportScreenViews, variables: {screens: ['a1', 's2', 'a1']}})
+    .then(({data: {reportScreenViews}}) => expect(reportScreenViews).toBe(true))
+
+  // verify reporting over 100 screens is an error
+  await expect(
+    anonClient.mutate({
+      mutation: mutations.reportScreenViews,
+      variables: {screens: Array(101).fill('arbitrary')},
+    }),
   ).rejects.toThrow(/ClientError: A max of 100 screens /)
 })

--- a/real-main/app/handlers/appsync/handlers.py
+++ b/real-main/app/handlers/appsync/handlers.py
@@ -494,7 +494,7 @@ def delete_user(caller_user_id, arguments, client=None, **kwargs):
 
 
 @routes.register('Mutation.reportScreenViews')
-@validate_caller
+@validate_caller(allowed_statuses=(UserStatus.ACTIVE, UserStatus.ANONYMOUS))
 @update_last_client
 @update_last_disable_dating_date
 def report_screen_views(caller_user, arguments, **kwargs):


### PR DESCRIPTION
Fixes: https://trello.com/c/4Z0fTPh9/35-anonymous-users-should-be-able-to-submit-a-post-view