### PR TITLE
Disable dating status if not validated while updating user details

### DIFF
--- a/integration-testing/schema/mutations.js
+++ b/integration-testing/schema/mutations.js
@@ -160,6 +160,7 @@ module.exports.setUserDetails = gql`
       gender
       matchGenders
       matchLocationRadius
+      datingStatus
     }
   }
   ${fragments.image}

--- a/real-main/app/models/user/model.py
+++ b/real-main/app/models/user/model.py
@@ -334,6 +334,12 @@ class User(TrendingModelMixin):
         kwargs = {k: v for k, v in kwargs.items() if v != self.item.get(stringcase.camelcase(k), '')}
         if kwargs:
             self.item = self.dynamo.set_user_details(self.id, **kwargs)
+
+        # disable dating status if not validated
+        try:
+            self.validate_can_enable_dating()
+        except UserException:
+            return self.set_dating_status(UserDatingStatus.DISABLED)
         return self
 
     def update_age(self, now=None):

--- a/real-main/app_tests/models/user/test_manager_on_user_change_update_dating.py
+++ b/real-main/app_tests/models/user/test_manager_on_user_change_update_dating.py
@@ -90,8 +90,8 @@ def test_on_user_change_update_dating_disables_dating_if_dating_validation_fails
     user.update_details(full_name='')
     with pytest.raises(UserException, match='fullName'):
         user.validate_can_enable_dating()
-    assert user.item['datingStatus'] == UserDatingStatus.ENABLED
+    assert 'datingStatus' not in user.refresh_item().item
     with patch.object(user_manager, 'real_dating_client') as rdc_mock:
         user_manager.on_user_change_update_dating(user.id, new_item=user.item, old_item=old_item)
-    assert rdc_mock.mock_calls == []
+    assert rdc_mock.mock_calls == [call.remove_user(user.id)]
     assert 'datingStatus' not in user.refresh_item().item


### PR DESCRIPTION
Fixes: https://trello.com/c/ZyNpWgTB/40-update-datingstatus-to-disabled-while-updating-user-profile-with-missing-dating-variables