### PR TITLE
Update lastDeflatedAt even if the score is zero

### DIFF
--- a/real-main/app/mixins/trending/dynamo.py
+++ b/real-main/app/mixins/trending/dynamo.py
@@ -66,7 +66,8 @@ class TrendingDynamo:
         assert isinstance(expected_score, Decimal), 'Boto uses decimals for numbers'
         assert isinstance(new_score, Decimal), 'Boto uses decimals for numbers'
         assert new_score >= 0, 'Score cannot be negative'
-        assert expected_score > new_score, 'New score must be less than existing score'
+        # expected_score == new_score means they are all zero
+        assert expected_score >= new_score, 'New score must be less than or equal to existing score'
         query_kwargs = {
             'Key': self.pk(item_id),
             'UpdateExpression': 'SET gsiA4SortKey = :ns, lastDeflatedAt = :lda',

--- a/real-main/app/mixins/trending/manager.py
+++ b/real-main/app/mixins/trending/manager.py
@@ -44,7 +44,6 @@ class TrendingManagerMixin:
         current_score = trending_item['gsiA4SortKey']
         if current_score == 0:
             logging.warning(f'Trending for item `{self.item_type}:{item_id}` already has score of zero')
-            return False
 
         now = now or pendulum.now('utc')
         last_deflation_at = pendulum.parse(trending_item['lastDeflatedAt'])

--- a/real-main/app_tests/mixins/trending/test_dynamo.py
+++ b/real-main/app_tests/mixins/trending/test_dynamo.py
@@ -114,7 +114,7 @@ def test_deflate_score_failures(trending_dynamo):
         trending_dynamo.deflate_score(item_id, Decimal(5), Decimal(-1), yesterday, now)
 
     # verify can't deflate to more than our score
-    with pytest.raises(AssertionError, match='less than existing'):
+    with pytest.raises(AssertionError, match='less than'):
         trending_dynamo.deflate_score(item_id, Decimal(5), Decimal(6), yesterday, now)
 
     # verify can't deflate trending that DNE

--- a/real-main/app_tests/mixins/trending/test_manager.py
+++ b/real-main/app_tests/mixins/trending/test_manager.py
@@ -82,7 +82,7 @@ def test_trending_deflate_item_already_has_score_of_zero(manager, caplog):
     with caplog.at_level(logging.WARNING):
         deflated = manager.trending_deflate_item(item)
     assert deflated is False
-    assert len(caplog.records) == 1
+    assert len(caplog.records) == 2
     assert manager.item_type in caplog.records[0].msg
     assert item_id in caplog.records[0].msg
     assert 'already has score of zero' in caplog.records[0].msg


### PR DESCRIPTION
Fixes: https://trello.com/c/6O1o9xcJ/52-investigate-cloudwatch-error-addscore-method-in-trendingdynamo