### PR TITLE
Revert idp list verified contacts PR 88

### DIFF
--- a/real-main/app/clients/cognito.py
+++ b/real-main/app/clients/cognito.py
@@ -172,18 +172,6 @@ class CognitoClient:
             user_items.append(user_item)
         return user_items
 
-    def list_verified_contact_users(self, attribute_name, attribute_value):
-        filter_query = f'{attribute_name} = "{attribute_value}" AND {attribute_name}_verified = "true"'
-        boto_resp = self.user_pool_client.list_users(UserPoolId=self.user_pool_id, Filter=filter_query)
-
-        user_items = []
-        for resp_item in boto_resp['Users']:
-            user_item = {ua['Name']: ua['Value'] for ua in resp_item['Attributes']}
-            user_item['Username'] = resp_item['Username']
-            user_items.append(user_item)
-        logger.warning(f'Verified contact users `{user_items}`')
-        return user_items
-
     def delete_user_pool_entry(self, user_id):
         self.user_pool_client.admin_delete_user(UserPoolId=self.user_pool_id, Username=user_id)
 

--- a/real-main/app/models/user/model.py
+++ b/real-main/app/models/user/model.py
@@ -383,8 +383,7 @@ class User(TrendingModelMixin):
         # verify that new attribtue value is not used by other
         contact_attr_dynamo = getattr(self, names['dynamo_client'])
         if contact_attr_dynamo.get(attribute_value):
-            if self.cognito_client.list_verified_contact_users(names['cognito'], attribute_value):
-                raise UserException(f'User {names["dynamo_attr"]} is already used by other')
+            raise UserException(f'User {names["dynamo_attr"]} is already used by other')
 
         self.cognito_client.set_user_attributes(self.id, attrs)
 

--- a/real-main/app_tests/models/user/test_model.py
+++ b/real-main/app_tests/models/user/test_model.py
@@ -423,10 +423,6 @@ def test_start_change_phone_steal_other_one(user_1_verified_phone_stream_updated
     assert 'phoneNumber' in user_1_verified_phone_stream_updated.item
     assert 'phoneNumber' in user_verified_phone.item
 
-    user_verified_phone.cognito_client.list_verified_contact_users = Mock(
-        return_value=[{'Username': user_1_verified_phone_stream_updated.id}]
-    )
-
     new_phone = user_1_verified_phone_stream_updated.item.get('phoneNumber')
     with pytest.raises(UserException, match='User phoneNumber is already used by other'):
         user_verified_phone.start_change_contact_attribute('phone', new_phone)
@@ -491,8 +487,6 @@ def test_start_change_email_same_as_existing(user):
 def test_start_change_email_steal_other_one(user_4_stream_updated, user):
     assert 'email' in user_4_stream_updated.item
     assert 'email' in user.item
-
-    user.cognito_client.list_verified_contact_users = Mock(return_value=[{'Username': user_4_stream_updated.id}])
 
     new_email = user_4_stream_updated.item.get('email')
     with pytest.raises(UserException, match='User email is already used by other'):


### PR DESCRIPTION
@real-ian I created this PR for reverting the old https://github.com/real-social-media/backend/pull/88/ that supposed to fix the steal user email/phone feature.
I just noticed that the old code is unnecessary and doesn't do anything because we cannot query the custom attrs in the `list_users`.
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cognito-idp.html#CognitoIdentityProvider.Client.list_users
![image](https://user-images.githubusercontent.com/4212008/99441399-884a3d80-2963-11eb-82fa-9caf12c16ce2.png)
