### PR TITLE
Prevent re-enable dating within 3 hours

### DIFF
--- a/integration-testing/tests/dating/match-criteria.test.js
+++ b/integration-testing/tests/dating/match-criteria.test.js
@@ -121,16 +121,9 @@ test('Enable & disable dating changes match status', async () => {
     .then(({data: {user}}) => expect(user.matchStatus).toBe('NOT_MATCHED'))
 
   // we enable dating, check matches are back
-  await ourClient
-    .mutate({mutation: mutations.setUserDatingStatus, variables: {status: 'ENABLED'}})
-    .then(({data: {setUserDatingStatus: user}}) => expect(user.datingStatus).toBe('ENABLED'))
-  await misc.sleep(2000)
-  await ourClient
-    .query({query: queries.user, variables: {userId: theirUserId}})
-    .then(({data: {user}}) => expect(user.matchStatus).toBe('POTENTIAL'))
-  await theirClient
-    .query({query: queries.user, variables: {userId: ourUserId}})
-    .then(({data: {user}}) => expect(user.matchStatus).toBe('POTENTIAL'))
+  await expect(
+    ourClient.mutate({mutation: mutations.setUserDatingStatus, variables: {status: 'ENABLED'}}),
+  ).rejects.toThrow(/ClientError: User cannot re-enable dating within 3 hours/)
 })
 
 test('Changing match criteria changes match status', async () => {

--- a/integration-testing/tests/dating/set-dating-status.test.js
+++ b/integration-testing/tests/dating/set-dating-status.test.js
@@ -82,6 +82,11 @@ test('Enable, disable dating as a BASIC user, privacy', async () => {
     expect(user.datingStatus).toBe('DISABLED')
     expect(user.userDisableDatingDate).toBeDefined()
   })
+
+  // we cannot re-enable dating within 3 hours
+  await expect(
+    ourClient.mutate({mutation: mutations.setUserDatingStatus, variables: {status: 'ENABLED'}}),
+  ).rejects.toThrow(/ClientError: User cannot re-enable dating within 3 hours/)
 })
 
 test('FullName required to enable dating', async () => {

--- a/real-main/app/models/user/model.py
+++ b/real-main/app/models/user/model.py
@@ -530,6 +530,17 @@ class User(TrendingModelMixin):
             return self
         if status == UserDatingStatus.ENABLED:
             self.validate_can_enable_dating()
+
+            # don't allow users to enable dating if they disabled it within 3 hours
+            now = pendulum.now('utc')
+            user_disable_dating_date = self.item.get('userDisableDatingDate')
+
+            if (
+                user_disable_dating_date is not None
+                and (now - pendulum.parse(user_disable_dating_date)).hours < 3
+            ):
+                raise UserException('User cannot re-enable dating within 3 hours')
+
         self.item = self.dynamo.set_user_dating_status(self.id, status)
         return self
 

--- a/real-main/app_tests/models/user/test_model.py
+++ b/real-main/app_tests/models/user/test_model.py
@@ -1094,6 +1094,39 @@ def test_set_dating_status(user):
     assert user.item == user.refresh_item().item
 
 
+def test_enable_dating_status_with_last_disable_dating_date(user):
+    assert 'datingStatus' not in user.item
+
+    # verify set to disabled when disabled is no-op
+    with patch.object(user, 'dynamo') as mock_dynamo:
+        user.set_dating_status(UserDatingStatus.DISABLED)
+    assert mock_dynamo.mock_calls == []
+    assert 'datingStatus' not in user.refresh_item().item
+
+    # verify enabling success case
+    with patch.object(user, 'validate_can_enable_dating'):
+        user.set_dating_status(UserDatingStatus.ENABLED)
+    assert user.item['datingStatus'] == UserDatingStatus.ENABLED
+    assert user.item == user.refresh_item().item
+
+    # disable dating status
+    user.set_dating_status(UserDatingStatus.DISABLED)
+    assert 'datingStatus' not in user.item
+    assert 'userDisableDatingDate' in user.item
+
+    # try to enable dating, verify failed
+    user.item['userDisableDatingDate'] = (pendulum.now('utc') - pendulum.duration(hours=2)).to_iso8601_string()
+    with patch.object(user, 'validate_can_enable_dating'):
+        with pytest.raises(UserException):
+            user.set_dating_status(UserDatingStatus.ENABLED)
+
+    # try to enable dating, verify success
+    user.item['userDisableDatingDate'] = (pendulum.now('utc') - pendulum.duration(hours=3)).to_iso8601_string()
+    with patch.object(user, 'validate_can_enable_dating'):
+        user.set_dating_status(UserDatingStatus.ENABLED)
+    assert user.item['datingStatus'] == UserDatingStatus.ENABLED
+
+
 def test_generate_dating_profile(user):
     # minimal profile
     assert user.generate_dating_profile() == {'serviceLevel': UserSubscriptionLevel.BASIC}


### PR DESCRIPTION
Fixes: https://trello.com/c/vdkYvVnC/70-add-lastenableddating-timestamp-to-user-profile