### PR TITLE
Users who are banned should not be able to sign up again

### DIFF
--- a/real-main/app/models/user/dynamo/base.py
+++ b/real-main/app/models/user/dynamo/base.py
@@ -558,4 +558,4 @@ class UserDynamo:
                 'IndexName': 'GSI-A3',
             }
 
-        return (key['partitionKey'].split('/')[1] for key in self.client.generate_all_query(query_kwargs))
+        return [key['partitionKey'].split('/')[1] for key in self.client.generate_all_query(query_kwargs)]

--- a/real-main/app_tests/models/user/test_dynamo.py
+++ b/real-main/app_tests/models/user/test_dynamo.py
@@ -1065,15 +1065,15 @@ def test_generate_banned_user_by_contact_attr(user_dynamo, caplog):
     user_dynamo.add_user_banned(user_id_3, 'abc-3', 'chatMessages', device='x-real-device-1')
 
     user_ids = user_dynamo.generate_banned_user_by_contact_attr(email='abc1@test.com')
-    assert list(user_ids) == [user_id_1]
+    assert user_ids == [user_id_1]
     user_ids = user_dynamo.generate_banned_user_by_contact_attr(phone='+1234567890')
-    assert list(user_ids) == [user_id_2]
+    assert user_ids == [user_id_2]
     user_ids = user_dynamo.generate_banned_user_by_contact_attr(device='x-real-device-1')
-    assert list(user_ids) == [user_id_3]
+    assert user_ids == [user_id_3]
 
     user_ids = user_dynamo.generate_banned_user_by_contact_attr(device='x-real-device')
-    assert list(user_ids) == []
+    assert user_ids == []
     user_ids = user_dynamo.generate_banned_user_by_contact_attr(email='abc@test.com')
-    assert list(user_ids) == []
+    assert user_ids == []
     user_ids = user_dynamo.generate_banned_user_by_contact_attr(phone='1234567890')
-    assert list(user_ids) == []
+    assert user_ids == []


### PR DESCRIPTION
Fixes: https://trello.com/c/GSOXY60r/72-users-who-are-banned-should-not-be-able-to-sign-up-again-that-deviceid-email-and-phone-number-should-be-blacklisted-from-signup