### PR TITLE
Change free diamond trial to 1 month

### DIFF
--- a/integration-testing/tests/users/real-subscription.test.js
+++ b/integration-testing/tests/users/real-subscription.test.js
@@ -32,7 +32,7 @@ test('Grant a user a free diamond subscription', async () => {
   })
 
   // we give grant ourselves our subscription bonus
-  const subscriptionDuration = moment.duration(3, 'months')
+  const subscriptionDuration = moment.duration(1, 'months')
   const before = moment().add(subscriptionDuration).toISOString()
   const expiresAt = await ourClient
     .mutate({mutation: mutations.grantUserSubscriptionBonus})

--- a/real-main/app/models/user/model.py
+++ b/real-main/app/models/user/model.py
@@ -42,7 +42,7 @@ class User(TrendingModelMixin):
 
     client_names = ['cloudfront', 'cognito', 'elasticsearch', 'dynamo', 'pinpoint', 's3_uploads']
     item_type = 'user'
-    subscription_bonus_duration = pendulum.duration(months=3)
+    subscription_bonus_duration = pendulum.duration(months=1)
 
     def __init__(
         self,

--- a/real-main/app_tests/models/user/test_manager.py
+++ b/real-main/app_tests/models/user/test_manager.py
@@ -172,7 +172,7 @@ def test_username_tag_regex(user_manager):
 
 
 def test_clear_expired_subscriptions(user_manager, user1, user2, user3):
-    sub_duration = pendulum.duration(months=3)
+    sub_duration = pendulum.duration(months=1)
     ms = pendulum.duration(microseconds=1)
 
     # grant these users subscriptions that expire at different times, verify

--- a/real-main/app_tests/models/user/test_model.py
+++ b/real-main/app_tests/models/user/test_model.py
@@ -812,7 +812,7 @@ def test_grant_subscription_bonus(user):
     assert user.subscription_level == UserSubscriptionLevel.BASIC
     assert 'subscriptionGrantedAt' not in user.item
     assert 'subscriptionExpiresAt' not in user.item
-    sub_duration = pendulum.duration(months=3)
+    sub_duration = pendulum.duration(months=1)
 
     # grant a subscription
     before = pendulum.now('utc')


### PR DESCRIPTION
Fixes: https://trello.com/c/d3skhu1i/98-change-real-diamond-subscription-cost-to-be-099-mo-with-1-month-free-apple-pay-free-trial
https://trello.com/c/sspQrlGp/342-after-find-invite-10-friends-tell-the-user-after-closing-this-menu-free-real-diamond-for-1-month-see-description