### PR TITLE
Change chat notification delay

### DIFF
--- a/real-main/app/models/card/templates.py
+++ b/real-main/app/models/card/templates.py
@@ -19,7 +19,7 @@ class CardTemplate:
 class ChatCardTemplate(CardTemplate):
 
     action = 'https://real.app/chat/'
-    notify_user_after = pendulum.duration(minutes=5)
+    notify_user_after = pendulum.duration(seconds=5)
 
     @staticmethod
     def get_card_id(user_id):


### PR DESCRIPTION
https://trello.com/c/iJ6Ofu0u/101-currently-push-notifications-for-chat-messages-are-sent-after-5-minutes-lets-change-that-time-to-be-instantly-when-a-chat-messag