### PR TITLE
Undo follow real users for new users

### DIFF
--- a/integration-testing/tests/users/autofollow-the-real-user.sequential.test.js
+++ b/integration-testing/tests/users/autofollow-the-real-user.sequential.test.js
@@ -25,7 +25,7 @@ afterAll(async () => {
   await loginCache.reset()
 })
 
-test('new users auto-follow a user with username `real`, if they exist', async () => {
+test.skip('new users auto-follow a user with username `real`, if they exist', async () => {
   const {userId: realUserId} = realLogin
 
   // create a new user. Should auto-follow the real user

--- a/real-main/app/models/user/manager.py
+++ b/real-main/app/models/user/manager.py
@@ -166,7 +166,6 @@ class UserManager(TrendingManagerMixin, ManagerBase):
             user_id, username, placeholder_photo_code=photo_code, status=UserStatus.ANONYMOUS
         )
         user = self.init_user(item)
-        self.follow_real_user(user)
         return user, tokens
 
     def create_cognito_only_user(self, user_id, username, full_name=None):
@@ -215,7 +214,6 @@ class UserManager(TrendingManagerMixin, ManagerBase):
             raise
 
         user = self.init_user(item)
-        self.follow_real_user(user)
         return user
 
     def create_federated_user(self, provider, user_id, username, token, full_name=None):
@@ -266,7 +264,6 @@ class UserManager(TrendingManagerMixin, ManagerBase):
             user_id, username, full_name=full_name, email=email, placeholder_photo_code=photo_code
         )
         user = self.init_user(item)
-        self.follow_real_user(user)
         return user
 
     def follow_real_user(self, user):

--- a/real-main/app_tests/models/user/test_manager_create_anonymous_user.py
+++ b/real-main/app_tests/models/user/test_manager_create_anonymous_user.py
@@ -45,11 +45,6 @@ def test_create_anonymous_user_success(user_manager, real_user):
         ),
     ]
 
-    # check we are following the real user
-    followeds = list(user.follower_manager.dynamo.generate_followed_items(user.id))
-    assert len(followeds) == 1
-    assert followeds[0]['followedUserId'] == real_user.id
-
 
 def test_create_anonymous_user_user_id_taken(user_manager):
     # configure cognito to respond as if user_id is already taken

--- a/real-main/app_tests/models/user/test_manager_create_cognito_only_user.py
+++ b/real-main/app_tests/models/user/test_manager_create_cognito_only_user.py
@@ -207,13 +207,3 @@ def test_create_cognito_only_user_follow_real_user_doesnt_exist(user_manager, co
     cognito_client.create_user_pool_entry(user_id, username, verified_email=f'{username}@real.app')
     user = user_manager.create_cognito_only_user(user_id, username)
     assert list(user.follower_manager.dynamo.generate_followed_items(user.id)) == []
-
-
-def test_create_cognito_only_user_follow_real_user_if_exists(user_manager, cognito_client, real_user):
-    # create a user, verify follows real user
-    user_id, username = str(uuid4()), str(uuid4())[:8]
-    cognito_client.create_user_pool_entry(user_id, username, verified_email=f'{username}@real.app')
-    user = user_manager.create_cognito_only_user(user_id, username)
-    followeds = list(user.follower_manager.dynamo.generate_followed_items(user.id))
-    assert len(followeds) == 1
-    assert followeds[0]['followedUserId'] == real_user.id

--- a/real-main/app_tests/models/user/test_manager_create_federated_user.py
+++ b/real-main/app_tests/models/user/test_manager_create_federated_user.py
@@ -50,11 +50,6 @@ def test_create_federated_user_success(user_manager, real_user, provider):
         mock.call(user_id, **call_kwargs)
     ]
 
-    # check we are following the real user
-    followeds = list(user.follower_manager.dynamo.generate_followed_items(user.id))
-    assert len(followeds) == 1
-    assert followeds[0]['followedUserId'] == real_user.id
-
 
 @pytest.mark.parametrize('provider', ['apple', 'facebook', 'google'])
 def test_create_federated_user_user_id_taken(user_manager, provider):


### PR DESCRIPTION
Fixes: https://trello.com/c/GW8Ycoot/119-by-default-new-users-all-follow-the-real-user-please-undo-this-so-that-new-users-dont-follow-anyone-in-production