### PR TITLE
Optimize trending query

### DIFF
--- a/integration-testing/schema/queries.js
+++ b/integration-testing/schema/queries.js
@@ -542,15 +542,15 @@ module.exports.trendingUsers = gql`
 `
 
 module.exports.trendingPosts = gql`
-  query TrendingPosts($limit: Int, $viewedStatus: ViewedStatus, $isVerified: Boolean) {
+  query TrendingPosts($limit: Int, $isVerified: Boolean) {
     trendingPosts(limit: $limit) {
-      items(viewedStatus: $viewedStatus, isVerified: $isVerified) {
+      items(isVerified: $isVerified) {
         postId
         postedBy {
           userId
           privacyStatus
-          blockerStatus
-          followedStatus
+          # blockerStatus
+          # followedStatus
         }
         viewedStatus
       }

--- a/real-main/app/mixins/trending/manager.py
+++ b/real-main/app/mixins/trending/manager.py
@@ -12,7 +12,7 @@ class TrendingManagerMixin:
 
     score_inflation_per_day = 2
 
-    min_count_to_keep = 10 * 1000
+    min_count_to_keep = 10 * 100
     min_score_to_keep = 0.5
 
     def __init__(self, clients, managers=None):

--- a/real-main/app/mixins/trending/manager.py
+++ b/real-main/app/mixins/trending/manager.py
@@ -1,9 +1,12 @@
 import logging
+import os
 
 import pendulum
 
 from .dynamo import TrendingDynamo
 from .exceptions import TrendingDNEOrAttributeMismatch
+
+TRENDING_POST_MIN_COUNT_TO_KEEP = os.environ.get('TRENDING_POST_MIN_COUNT_TO_KEEP')
 
 logger = logging.getLogger()
 
@@ -12,7 +15,7 @@ class TrendingManagerMixin:
 
     score_inflation_per_day = 2
 
-    min_count_to_keep = 10 * 100
+    min_count_to_keep = int(TRENDING_POST_MIN_COUNT_TO_KEEP) if TRENDING_POST_MIN_COUNT_TO_KEEP else 10 * 100
     min_score_to_keep = 0.5
 
     def __init__(self, clients, managers=None):

--- a/real-main/app/models/post/manager.py
+++ b/real-main/app/models/post/manager.py
@@ -12,7 +12,7 @@ from app.mixins.trending.manager import TrendingManagerMixin
 from app.mixins.view.enums import ViewType
 from app.mixins.view.manager import ViewManagerMixin
 from app.models.like.enums import LikeStatus
-from app.models.user.enums import UserSubscriptionLevel
+from app.models.user.enums import UserPrivacyStatus, UserSubscriptionLevel
 from app.utils import GqlNotificationType
 
 from .appsync import PostAppSync
@@ -440,8 +440,11 @@ class PostManager(FlagManagerMixin, TrendingManagerMixin, ViewManagerMixin, Mana
 
     def on_post_view_change_update_trending(self, post_id, new_item, old_item=None):
         # only COMPLETED posts should exist in trending
+        # poster privacy status should not be PRIVATE
         post = self.get_post(post_id)
         if not post or post.status != PostStatus.COMPLETED:
+            return
+        if post.user.item.get('privacyStatus') == UserPrivacyStatus.PRIVATE:
             return
 
         # a user's views of their own post don't earning trending points

--- a/real-main/app/models/post/model.py
+++ b/real-main/app/models/post/model.py
@@ -377,8 +377,10 @@ class Post(FlagModelMixin, TrendingModelMixin, ViewModelMixin):
             self.follower_manager.refresh_first_story(story_now=self.item)
 
         # give new posts a free bump into trending, but not their user
-        trending_kwargs = {'now': now, 'multiplier': self.get_trending_multiplier()}
-        self.trending_increment_score(**trending_kwargs)
+        # if poster's privacy status is PRIVATE, skip adding
+        if self.user.item.get('privacyStatus') != UserPrivacyStatus.PRIVATE:
+            trending_kwargs = {'now': now, 'multiplier': self.get_trending_multiplier()}
+            self.trending_increment_score(**trending_kwargs)
 
         # alert frontend
         self.appsync.trigger_notification(PostNotificationType.COMPLETED, self)

--- a/real-main/app_tests/mixins/trending/test_manager.py
+++ b/real-main/app_tests/mixins/trending/test_manager.py
@@ -158,12 +158,12 @@ def test_trending_deflate_item_with_recursion(manager, caplog):
 
 @pytest.mark.parametrize('manager', pytest.lazy_fixture(['user_manager', 'post_manager']))
 def test_trending_delete_tail(manager):
-    assert manager.min_count_to_keep == 10 * 1000
+    assert manager.min_count_to_keep == 10 * 100
     assert manager.min_score_to_keep == 0.5
     manager.trending_dynamo.delete = Mock(wraps=manager.trending_dynamo.delete)
 
     # test none to delete
-    cnt = manager.trending_delete_tail(10000)
+    cnt = manager.trending_delete_tail(1000)
     assert cnt == 0
     assert manager.trending_dynamo.delete.mock_calls == []
 
@@ -171,7 +171,7 @@ def test_trending_delete_tail(manager):
     manager.trending_dynamo.delete.reset_mock()
     item1_id, item1_score = str(uuid4()), Decimal(0.25)
     manager.trending_dynamo.add(item1_id, item1_score)
-    cnt = manager.trending_delete_tail(10001)
+    cnt = manager.trending_delete_tail(1001)
     assert cnt == 1
     assert manager.trending_dynamo.delete.mock_calls == [call(item1_id, expected_score=item1_score)]
     assert manager.trending_dynamo.get(item1_id) is None
@@ -184,7 +184,7 @@ def test_trending_delete_tail(manager):
     manager.trending_dynamo.add(item1_id, item1_score)
     manager.trending_dynamo.add(item2_id, item2_score)
     manager.trending_dynamo.add(item3_id, item3_score)
-    cnt = manager.trending_delete_tail(10002)
+    cnt = manager.trending_delete_tail(1002)
     assert cnt == 2
     assert manager.trending_dynamo.delete.mock_calls == [
         call(item2_id, expected_score=item2_score),
@@ -203,7 +203,7 @@ def test_trending_delete_tail(manager):
     manager.trending_dynamo.add(item1_id, item1_score)
     manager.trending_dynamo.add(item2_id, item2_score)
     manager.trending_dynamo.add(item3_id, item3_score)
-    cnt = manager.trending_delete_tail(10003)
+    cnt = manager.trending_delete_tail(1003)
     assert cnt == 1
     assert manager.trending_dynamo.delete.mock_calls == [
         call(item2_id, expected_score=item2_score),
@@ -215,7 +215,7 @@ def test_trending_delete_tail(manager):
 
 @pytest.mark.parametrize('manager', pytest.lazy_fixture(['user_manager', 'post_manager']))
 def test_trending_delete_tail_race_condition(manager, caplog):
-    assert manager.min_count_to_keep == 10 * 1000
+    assert manager.min_count_to_keep == 10 * 100
     assert manager.min_score_to_keep == 0.5
     manager.trending_dynamo.delete = Mock(wraps=manager.trending_dynamo.delete)
 
@@ -235,7 +235,7 @@ def test_trending_delete_tail_race_condition(manager, caplog):
 
     # do the tail delete
     with caplog.at_level(logging.WARNING):
-        cnt = manager.trending_delete_tail(10002)
+        cnt = manager.trending_delete_tail(1002)
     assert cnt == 1
     assert len(caplog.records) == 1
     assert 'not deleting trending' in caplog.records[0].msg

--- a/real-main/mapping-templates/PaginatedTrendingPosts.items/after.response.vtl
+++ b/real-main/mapping-templates/PaginatedTrendingPosts.items/after.response.vtl
@@ -1,0 +1,27 @@
+#if ($ctx.error)
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
+
+## requires $ctx.stash.userIdAttribute and $ctx.stash.userAttribute to be set
+#set ($userIdAttr = $ctx.stash.userIdAttribute)
+#set ($userAttr = $ctx.stash.userAttribute)
+#if (! $userIdAttr || ! $userAttr)
+  $util.error('$ctx.stash.userIdAttribute and $ctx.stash.userAttribute must be set', 'ServerError')
+#end
+
+## build a map from userId to user object
+#set ($userIdToUser = {})
+#foreach ($user in $ctx.prev.result)
+  $util.qr($userIdToUser.put($user.userId, $user))
+#end
+
+## filter out items that the user object was filtered out
+#set ($items = [])
+#foreach ($item in $ctx.stash.items)
+  #if ($userIdToUser.containsKey($item[$userIdAttr]))
+    $util.qr($item.put($userAttr, $userIdToUser[$item[$userIdAttr]]))
+    $util.qr($items.add($item))
+  #end
+#end
+
+$util.toJson($items)

--- a/real-main/mapping-templates/PaginatedTrendingPosts.items/applyFilters.request.vtl
+++ b/real-main/mapping-templates/PaginatedTrendingPosts.items/applyFilters.request.vtl
@@ -1,0 +1,16 @@
+#set ($callerUserId = $ctx.identity.cognitoIdentityId)
+#set ($isVerified = $ctx.args.isVerified)
+#set ($ctx.stash.posts = $ctx.prev.result)
+
+## if we're filtering on isVerified, do that now
+#if (!$util.isNull($isVerified))
+  #set ($posts = [])
+  #foreach ($post in $ctx.stash.posts)
+    #if ($post.isVerified == $isVerified)
+      $util.qr($posts.add($post))
+    #end
+  #end
+  #set ($ctx.stash.posts = $posts)
+#end
+
+#return ($ctx.stash.posts)

--- a/real-main/mapping-templates/PaginatedTrendingPosts.items/applyFilters.response.vtl
+++ b/real-main/mapping-templates/PaginatedTrendingPosts.items/applyFilters.response.vtl
@@ -1,0 +1,14 @@
+#if ($ctx.error)
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
+
+## Note: trying to #set() a variable to a computed null value
+##       doesn't work. Avoid: #set($item = arrayWithNulls[$index])
+
+## retrieve the results of the query
+#set ($posts = [])
+#foreach ($post in $ctx.stash.posts)
+  $util.qr($posts.add($post))
+#end
+
+$util.toJson($posts)

--- a/real-main/mapping-templates/PaginatedTrendingPosts.items/before.request.vtl
+++ b/real-main/mapping-templates/PaginatedTrendingPosts.items/before.request.vtl
@@ -1,0 +1,5 @@
+## For Users.beginPipeline & Users.endPipeline
+#set ($ctx.stash.userIdAttribute = 'postedByUserId')
+#set ($ctx.stash.userAttribute = 'postedBy')
+
+$util.toJson($ctx.source.items)

--- a/real-main/schema.graphql
+++ b/real-main/schema.graphql
@@ -64,7 +64,7 @@ type Query {
   similarPosts(postId: ID!, limit: Int, nextToken: String): PaginatedPosts!
 
   # Globally trending posts
-  trendingPosts(limit: Int, nextToken: String): PaginatedPosts!
+  trendingPosts(limit: Int, nextToken: String): PaginatedTrendingPosts!
 
   # Search keywords for autocomplete
   searchKeywords(keyword: String!): [String]!
@@ -863,6 +863,12 @@ type Post {
 type PaginatedPosts {
   # Set the optional arguments to filter down the set of returned posts
   items(viewedStatus: ViewedStatus, isVerified: Boolean): [Post!]!
+  nextToken: String
+}
+
+type PaginatedTrendingPosts {
+  # Set the optional arguments to filter down the set of returned posts
+  items(isVerified: Boolean): [Post!]!
   nextToken: String
 }
 

--- a/real-main/serverless.yml
+++ b/real-main/serverless.yml
@@ -160,6 +160,7 @@ custom:
     authenticationType: AWS_IAM
     caching:
       behavior: PER_RESOLVER_CACHING
+      type: 'LARGE_4X'
     logConfig:
       level: ERROR
     substitutions:

--- a/real-main/serverless.yml
+++ b/real-main/serverless.yml
@@ -60,6 +60,7 @@ provider:
 
     AMPLITUDE_API_KEY: ${env:AMPLITUDE_API_KEY, ''}
     APPLE_AUDIENCE_ID: ${env:AUTHENTICATION_PROVIDER_APPLEID, 'app.real.mobile'}
+    TRENDING_POST_MIN_COUNT_TO_KEEP: ${env:TRENDING_POST_MIN_COUNT_TO_KEEP, '1000'}
 
   iamRoleStatements:
     - Effect: Allow

--- a/real-main/serverless.yml
+++ b/real-main/serverless.yml
@@ -161,7 +161,6 @@ custom:
     authenticationType: AWS_IAM
     caching:
       behavior: PER_RESOLVER_CACHING
-      type: 'LARGE_4X'
     logConfig:
       level: ERROR
     substitutions:

--- a/real-main/serverless.yml
+++ b/real-main/serverless.yml
@@ -232,6 +232,18 @@ custom:
           - Users.filterBy.blockerStatus
           - Users.batchGet.followedStatus
           - Users.filterBy.followedStatus
+      
+      - type: PaginatedTrendingPosts
+        field: items
+        request: PaginatedTrendingPosts.items/before.request.vtl
+        response: PaginatedTrendingPosts.items/after.response.vtl  # temp copy of Users.endPipeline
+        kind: PIPELINE
+        functions:
+          - Posts.batchGet
+          - Posts.filterBy.postStatus
+          - PaginatedPosts.items.applyFilters
+          - Users.beginPipeline
+          - Users.batchGet
 
       - type: PaginatedUsers
         field: items

--- a/real-main/serverless/mapping-templates/query.yml
+++ b/real-main/serverless/mapping-templates/query.yml
@@ -53,6 +53,9 @@
 - type: Query
   field: trendingPosts
   dataSource: DynamodbDataSource
+  caching:
+    keys:
+      - $context.source.postId
 
 - type: Query
   field: album


### PR DESCRIPTION
https://trello.com/c/0BQ7q8jS/123-investigate-using-appsync-caching-to-cache-our-trending-query-see-description
https://trello.com/c/VExsB70c/122-dont-add-posts-of-private-accounts-to-trending-see-description
https://trello.com/c/40Y77xx8/121-limit-trending-from-10000-posts-to-be-maybe-1000-posts-see-if-it-helps-performance-mike-had-it-limited-to-10000-posts-somewhere