### PR TITLE
Update poetry lock file format

### DIFF
--- a/real-auth/poetry.lock
+++ b/real-auth/poetry.lock
@@ -1,19 +1,18 @@
 [[package]]
-category = "dev"
-description = "Atomic file writes."
-marker = "sys_platform == \"win32\""
 name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.4.0"
 
 [[package]]
-category = "dev"
-description = "Classes Without Boilerplate"
 name = "attrs"
+version = "19.3.0"
+description = "Classes Without Boilerplate"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "19.3.0"
 
 [package.extras]
 azure-pipelines = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "pytest-azurepipelines"]
@@ -22,12 +21,12 @@ docs = ["sphinx", "zope.interface"]
 tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 
 [[package]]
-category = "main"
-description = "The AWS X-Ray SDK for Python (the SDK) enables Python developers to record and emit information from within their applications to the AWS X-Ray service."
 name = "aws-xray-sdk"
+version = "2.5.0"
+description = "The AWS X-Ray SDK for Python (the SDK) enables Python developers to record and emit information from within their applications to the AWS X-Ray service."
+category = "main"
 optional = false
 python-versions = "*"
-version = "2.5.0"
 
 [package.dependencies]
 botocore = ">=1.11.3"
@@ -36,54 +35,50 @@ jsonpickle = "*"
 wrapt = "*"
 
 [[package]]
-category = "main"
-description = "Low-level, data-driven core of boto 3."
 name = "botocore"
+version = "1.16.7"
+description = "Low-level, data-driven core of boto 3."
+category = "main"
 optional = false
 python-versions = "*"
-version = "1.16.7"
 
 [package.dependencies]
 docutils = ">=0.10,<0.16"
 jmespath = ">=0.7.1,<1.0.0"
 python-dateutil = ">=2.1,<3.0.0"
-
-[package.dependencies.urllib3]
-python = "<3.4.0 || >=3.5.0"
-version = ">=1.20,<1.26"
+urllib3 = {version = ">=1.20,<1.26", markers = "python_version != \"3.4\""}
 
 [[package]]
-category = "dev"
-description = "Cross-platform colored terminal text."
-marker = "sys_platform == \"win32\""
 name = "colorama"
+version = "0.4.3"
+description = "Cross-platform colored terminal text."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.4.3"
 
 [[package]]
-category = "main"
-description = "Docutils -- Python Documentation Utilities"
 name = "docutils"
-optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "0.15.2"
-
-[[package]]
+description = "Docutils -- Python Documentation Utilities"
 category = "main"
-description = "Clean single-source support for Python 3 and 2"
-name = "future"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "0.18.2"
 
 [[package]]
+name = "future"
+version = "0.18.2"
+description = "Clean single-source support for Python 3 and 2"
 category = "main"
-description = "Read metadata from Python packages"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
 name = "importlib-metadata"
+version = "1.6.0"
+description = "Read metadata from Python packages"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.6.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -93,96 +88,96 @@ docs = ["sphinx", "rst.linker"]
 testing = ["packaging", "importlib-resources"]
 
 [[package]]
-category = "dev"
-description = "iniconfig: brain-dead simple config-ini parsing"
 name = "iniconfig"
-optional = false
-python-versions = "*"
 version = "1.0.1"
-
-[[package]]
-category = "main"
-description = "JSON Matching Expressions"
-name = "jmespath"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.9.5"
 
 [[package]]
+name = "jmespath"
+version = "0.9.5"
+description = "JSON Matching Expressions"
 category = "main"
-description = "Python library for serializing any arbitrary object graph into JSON"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "jsonpickle"
+version = "1.4.1"
+description = "Python library for serializing any arbitrary object graph into JSON"
+category = "main"
 optional = false
 python-versions = ">=2.7"
-version = "1.4.1"
 
 [package.dependencies]
 importlib-metadata = "*"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["coverage (<5)", "pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-black-multipy", "pytest-cov", "ecdsa", "feedparser", "numpy", "pandas", "pymongo", "sqlalchemy", "enum34", "jsonlib"]
+testing = ["coverage (<5)", "pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-black-multipy", "pytest-cov", "ecdsa", "feedparser", "numpy", "pandas", "pymongo", "sqlalchemy", "enum34", "jsonlib"]
 "testing.libs" = ["demjson", "simplejson", "ujson", "yajl"]
 
 [[package]]
-category = "dev"
-description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
+version = "8.2.0"
+description = "More routines for operating on iterables, beyond itertools"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "8.2.0"
 
 [[package]]
-category = "dev"
-description = "Core utilities for Python packages"
 name = "packaging"
+version = "20.3"
+description = "Core utilities for Python packages"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.3"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
 six = "*"
 
 [[package]]
-category = "dev"
-description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
+version = "0.13.1"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.13.1"
 
 [package.extras]
 dev = ["pre-commit", "tox"]
 
 [[package]]
-category = "dev"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
 name = "py"
+version = "1.9.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.9.0"
 
 [[package]]
-category = "dev"
-description = "Python parsing module"
 name = "pyparsing"
+version = "2.4.7"
+description = "Python parsing module"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.7"
 
 [[package]]
-category = "dev"
-description = "pytest: simple powerful testing with Python"
 name = "pytest"
+version = "6.0.1"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "6.0.1"
 
 [package.dependencies]
-atomicwrites = ">=1.0"
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=17.4.0"
-colorama = "*"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
 iniconfig = "*"
 more-itertools = ">=4.0.0"
 packaging = "*"
@@ -191,73 +186,73 @@ py = ">=1.8.2"
 toml = "*"
 
 [package.extras]
-checkqa_mypy = ["mypy (0.780)"]
+checkqa_mypy = ["mypy (==0.780)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
-category = "main"
-description = "Extensions to the standard Python datetime module"
 name = "python-dateutil"
+version = "2.8.1"
+description = "Extensions to the standard Python datetime module"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-version = "2.8.1"
 
 [package.dependencies]
 six = ">=1.5"
 
 [[package]]
-category = "main"
-description = "Python 2 and 3 compatibility utilities"
 name = "six"
+version = "1.14.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.14.0"
 
 [[package]]
-category = "dev"
-description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
+version = "0.10.1"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.10.1"
 
 [[package]]
-category = "main"
-description = "HTTP library with thread-safe connection pooling, file post, and more."
-marker = "python_version != \"3.4\""
 name = "urllib3"
+version = "1.25.9"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.25.9"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
 secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
-category = "main"
-description = "Module for decorators, wrappers and monkey patching."
 name = "wrapt"
+version = "1.12.1"
+description = "Module for decorators, wrappers and monkey patching."
+category = "main"
 optional = false
 python-versions = "*"
-version = "1.12.1"
 
 [[package]]
-category = "main"
-description = "Backport of pathlib-compatible object wrapper for zip files"
 name = "zipp"
+version = "3.1.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "3.1.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "6d355a645f62607ac9df76b1f3447c981598cc64c985bcd23e13dc3754de9e23"
+lock-version = "1.1"
 python-versions = "^3.8"
+content-hash = "6d355a645f62607ac9df76b1f3447c981598cc64c985bcd23e13dc3754de9e23"
 
 [metadata.files]
 atomicwrites = [

--- a/real-cloudfront/poetry.lock
+++ b/real-cloudfront/poetry.lock
@@ -1,7 +1,8 @@
 package = []
 
 [metadata]
-content-hash = "fafb334cb038533f851c23d0b63254223abf72ce4f02987e7064b0c95566699a"
+lock-version = "1.1"
 python-versions = "^3.8"
+content-hash = "fafb334cb038533f851c23d0b63254223abf72ce4f02987e7064b0c95566699a"
 
 [metadata.files]

--- a/real-lambda-layers/poetry.lock
+++ b/real-lambda-layers/poetry.lock
@@ -237,8 +237,8 @@ requests = ">=2.12,<3"
 six = ">=1.10.0"
 
 [package.extras]
-dev = ["flake8 (==3.7.9)", "isort (<4.0.0)", "black (==19.10b0)", "mypy (==0.761)", "check-manifest (>=0.40,<1)", "coveralls (==1.11.1)", "pytest-cov (==2.8.1)", "mock (==3.0.5)", "vcrpy (==3.0.0)", "pytest (==5.4.1)", "pytest-asyncio (==0.11.0)"]
-test = ["coveralls (==1.11.1)", "pytest-cov (==2.8.1)", "mock (==3.0.5)", "vcrpy (==3.0.0)", "pytest (==5.4.1)", "pytest-asyncio (==0.11.0)"]
+dev = ["flake8 (==3.7.9)", "check-manifest (>=0.40,<1)", "coveralls (==1.11.1)", "pytest (==4.6.9)", "pytest-cov (==2.8.1)", "mock (==3.0.5)", "vcrpy (==3.0.0)"]
+test = ["coveralls (==1.11.1)", "pytest (==4.6.9)", "pytest-cov (==2.8.1)", "mock (==3.0.5)", "vcrpy (==3.0.0)"]
 
 [[package]]
 name = "graphql-core"
@@ -791,7 +791,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "04eddec3f8755eba3ec428797ec96a13ab4fbb85df8c9938ed5f7bfde5846f53"
+content-hash = "0c06287fdd1cd372eb7c963bf32066b38aa16c92e08a3d0a84f9953ff5b4a827"
 
 [metadata.files]
 amplitude-python = [
@@ -866,6 +866,7 @@ chardet = [
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 colorthief = [
     {file = "colorthief-0.2.1-py2.py3-none-any.whl", hash = "sha256:b04fc8ce5cf9c888768745e29cb19b7b688d5711af6fba26e8057debabec56b9"},
@@ -919,7 +920,6 @@ google-auth = [
     {file = "google_auth-1.13.1-py2.py3-none-any.whl", hash = "sha256:cab6c707e6ee20e567e348168a5c69dc6480384f777a9e5159f4299ad177dcc0"},
 ]
 gql = [
-    {file = "gql-0.4.0-py2.py3-none-any.whl", hash = "sha256:6ecbb91ec321f867b3c4a9ddd9bab09f7eacffd8c0f86b3bda7809b6feee3f95"},
     {file = "gql-0.4.0.tar.gz", hash = "sha256:259b0c66d8dfe61feb06fe45b57713da0fe2e5ca13fa500a1fafc9bf2f195e81"},
 ]
 graphql-core = [
@@ -1041,8 +1041,6 @@ pillow = [
     {file = "Pillow-7.2.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:5e51ee2b8114def244384eda1c82b10e307ad9778dac5c83fb0943775a653cd8"},
     {file = "Pillow-7.2.0-cp38-cp38-win32.whl", hash = "sha256:725aa6cfc66ce2857d585f06e9519a1cc0ef6d13f186ff3447ab6dff0a09bc7f"},
     {file = "Pillow-7.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:a060cf8aa332052df2158e5a119303965be92c3da6f2d93b6878f0ebca80b2f6"},
-    {file = "Pillow-7.2.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:9c87ef410a58dd54b92424ffd7e28fd2ec65d2f7fc02b76f5e9b2067e355ebf6"},
-    {file = "Pillow-7.2.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:e901964262a56d9ea3c2693df68bc9860b8bdda2b04768821e4c44ae797de117"},
     {file = "Pillow-7.2.0-pp36-pypy36_pp73-win32.whl", hash = "sha256:25930fadde8019f374400f7986e8404c8b781ce519da27792cbe46eabec00c4d"},
     {file = "Pillow-7.2.0.tar.gz", hash = "sha256:97f9e7953a77d5a70f49b9a48da7776dc51e9b738151b22dacf101641594a626"},
 ]
@@ -1091,7 +1089,6 @@ pygments = [
     {file = "Pygments-2.7.3.tar.gz", hash = "sha256:ccf3acacf3782cbed4a989426012f1c535c9a90d3a7fc3f16d231b9372d2b716"},
 ]
 pyheif = [
-    {file = "pyheif-0.5.1-cp36-cp36m-manylinux2014_armv7l.whl", hash = "sha256:5345bd60dd2f23df17f4baac2ca9ffd278aa15336f01cfd4584f89d513c1d500"},
     {file = "pyheif-0.5.1-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:6e998cd4730e7c091f1d84ce23902ab873afca3b1458552700c89dbe0a85e716"},
     {file = "pyheif-0.5.1-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:ee1f757bf097cfc00a26dac8ac14de754727c7df53dcc1d79fdc6e36d4b941fe"},
     {file = "pyheif-0.5.1-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:0c25951387bea808b50c09215ddf828cfb6d834ca7bec652151272e53a809288"},

--- a/real-lambda-layers/pyproject.toml
+++ b/real-lambda-layers/pyproject.toml
@@ -23,6 +23,7 @@ aws-xray-sdk = "^2.5.0"
 stringcase = "^1.2.0"
 pyjwt = "^1.7.1"
 amplitude-python = "^0.13"
+requests-mock = "~1.8.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/real-main/poetry.lock
+++ b/real-main/poetry.lock
@@ -387,8 +387,8 @@ requests = ">=2.12,<3"
 six = ">=1.10.0"
 
 [package.extras]
-dev = ["flake8 (==3.7.9)", "isort (<4.0.0)", "black (==19.10b0)", "mypy (==0.761)", "check-manifest (>=0.40,<1)", "coveralls (==1.11.1)", "pytest-cov (==2.8.1)", "mock (==3.0.5)", "vcrpy (==3.0.0)", "pytest (==5.4.1)", "pytest-asyncio (==0.11.0)"]
-test = ["coveralls (==1.11.1)", "pytest-cov (==2.8.1)", "mock (==3.0.5)", "vcrpy (==3.0.0)", "pytest (==5.4.1)", "pytest-asyncio (==0.11.0)"]
+dev = ["flake8 (==3.7.9)", "check-manifest (>=0.40,<1)", "coveralls (==1.11.1)", "pytest (==4.6.9)", "pytest-cov (==2.8.1)", "mock (==3.0.5)", "vcrpy (==3.0.0)"]
+test = ["coveralls (==1.11.1)", "pytest (==4.6.9)", "pytest-cov (==2.8.1)", "mock (==3.0.5)", "vcrpy (==3.0.0)"]
 
 [[package]]
 name = "graphql-core"
@@ -1570,7 +1570,6 @@ google-auth = [
     {file = "google_auth-1.12.0-py2.py3-none-any.whl", hash = "sha256:01d686448f57d3bc027726474faa1aa650ba333bedb392e06938b0add8ec8d3a"},
 ]
 gql = [
-    {file = "gql-0.4.0-py2.py3-none-any.whl", hash = "sha256:6ecbb91ec321f867b3c4a9ddd9bab09f7eacffd8c0f86b3bda7809b6feee3f95"},
     {file = "gql-0.4.0.tar.gz", hash = "sha256:259b0c66d8dfe61feb06fe45b57713da0fe2e5ca13fa500a1fafc9bf2f195e81"},
 ]
 graphql-core = [
@@ -1762,8 +1761,6 @@ pillow = [
     {file = "Pillow-7.2.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:5e51ee2b8114def244384eda1c82b10e307ad9778dac5c83fb0943775a653cd8"},
     {file = "Pillow-7.2.0-cp38-cp38-win32.whl", hash = "sha256:725aa6cfc66ce2857d585f06e9519a1cc0ef6d13f186ff3447ab6dff0a09bc7f"},
     {file = "Pillow-7.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:a060cf8aa332052df2158e5a119303965be92c3da6f2d93b6878f0ebca80b2f6"},
-    {file = "Pillow-7.2.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:9c87ef410a58dd54b92424ffd7e28fd2ec65d2f7fc02b76f5e9b2067e355ebf6"},
-    {file = "Pillow-7.2.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:e901964262a56d9ea3c2693df68bc9860b8bdda2b04768821e4c44ae797de117"},
     {file = "Pillow-7.2.0-pp36-pypy36_pp73-win32.whl", hash = "sha256:25930fadde8019f374400f7986e8404c8b781ce519da27792cbe46eabec00c4d"},
     {file = "Pillow-7.2.0.tar.gz", hash = "sha256:97f9e7953a77d5a70f49b9a48da7776dc51e9b738151b22dacf101641594a626"},
 ]
@@ -1820,7 +1817,6 @@ pygments = [
     {file = "Pygments-2.7.3.tar.gz", hash = "sha256:ccf3acacf3782cbed4a989426012f1c535c9a90d3a7fc3f16d231b9372d2b716"},
 ]
 pyheif = [
-    {file = "pyheif-0.5.1-cp36-cp36m-manylinux2014_armv7l.whl", hash = "sha256:5345bd60dd2f23df17f4baac2ca9ffd278aa15336f01cfd4584f89d513c1d500"},
     {file = "pyheif-0.5.1-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:6e998cd4730e7c091f1d84ce23902ab873afca3b1458552700c89dbe0a85e716"},
     {file = "pyheif-0.5.1-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:ee1f757bf097cfc00a26dac8ac14de754727c7df53dcc1d79fdc6e36d4b941fe"},
     {file = "pyheif-0.5.1-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:0c25951387bea808b50c09215ddf828cfb6d834ca7bec652151272e53a809288"},


### PR DESCRIPTION
Poetry updated their lock file format in v1.1:  https://github.com/python-poetry/poetry/releases/tag/1.1.0a2

Some of these lock files were already updated to the new format, others not.

Note I added a pin of the version of requests-mock to the lambda layer package to avoid this bug: https://github.com/jamielennox/requests-mock/issues/170. Once that's fixed, we can update requests-mock and remove the version pin.