### PR TITLE
Remove requests mock version pin; upgrade

### DIFF
--- a/real-lambda-layers/poetry.lock
+++ b/real-lambda-layers/poetry.lock
@@ -589,7 +589,7 @@ requests = "*"
 
 [[package]]
 name = "requests-mock"
-version = "1.8.0"
+version = "1.9.2"
 description = "Mock out responses from the requests package"
 category = "main"
 optional = false
@@ -791,7 +791,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "0c06287fdd1cd372eb7c963bf32066b38aa16c92e08a3d0a84f9953ff5b4a827"
+content-hash = "04eddec3f8755eba3ec428797ec96a13ab4fbb85df8c9938ed5f7bfde5846f53"
 
 [metadata.files]
 amplitude-python = [
@@ -1131,8 +1131,8 @@ requests-aws4auth = [
     {file = "requests_aws4auth-0.9-py2.py3-none-any.whl", hash = "sha256:e20e4941ccd5706973068f9214d40cb2e669461536b3a57b9ac824ae87744c2c"},
 ]
 requests-mock = [
-    {file = "requests-mock-1.8.0.tar.gz", hash = "sha256:e68f46844e4cee9d447150343c9ae875f99fa8037c6dcf5f15bf1fe9ab43d226"},
-    {file = "requests_mock-1.8.0-py2.py3-none-any.whl", hash = "sha256:11215c6f4df72702aa357f205cf1e537cffd7392b3e787b58239bde5fb3db53b"},
+    {file = "requests-mock-1.9.2.tar.gz", hash = "sha256:33296f228d8c5df11a7988b741325422480baddfdf5dd9318fd0eb40c3ed8595"},
+    {file = "requests_mock-1.9.2-py2.py3-none-any.whl", hash = "sha256:5c8ef0254c14a84744be146e9799dc13ebc4f6186058112d9aeed96b131b58e2"},
 ]
 requests-toolbelt = [
     {file = "requests-toolbelt-0.9.1.tar.gz", hash = "sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"},

--- a/real-lambda-layers/pyproject.toml
+++ b/real-lambda-layers/pyproject.toml
@@ -23,7 +23,6 @@ aws-xray-sdk = "^2.5.0"
 stringcase = "^1.2.0"
 pyjwt = "^1.7.1"
 amplitude-python = "^0.13"
-requests-mock = "~1.8.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/real-main/poetry.lock
+++ b/real-main/poetry.lock
@@ -1076,7 +1076,7 @@ requests = "*"
 
 [[package]]
 name = "requests-mock"
-version = "1.8.0"
+version = "1.9.2"
 description = "Mock out responses from the requests package"
 category = "dev"
 optional = false
@@ -1361,7 +1361,7 @@ testing = ["pathlib2", "contextlib2", "unittest2"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "9fe13e49cb9911108b8263e9d9d4ed7f3d198a327a0f89fa32840a519dd25b6a"
+content-hash = "c234e91cd6874d8a64099503bea732d1c4d99ec7cad21f5a59eb5478733fe7c3"
 
 [metadata.files]
 amplitude-python = [
@@ -1947,8 +1947,8 @@ requests-aws4auth = [
     {file = "requests_aws4auth-0.9-py2.py3-none-any.whl", hash = "sha256:e20e4941ccd5706973068f9214d40cb2e669461536b3a57b9ac824ae87744c2c"},
 ]
 requests-mock = [
-    {file = "requests-mock-1.8.0.tar.gz", hash = "sha256:e68f46844e4cee9d447150343c9ae875f99fa8037c6dcf5f15bf1fe9ab43d226"},
-    {file = "requests_mock-1.8.0-py2.py3-none-any.whl", hash = "sha256:11215c6f4df72702aa357f205cf1e537cffd7392b3e787b58239bde5fb3db53b"},
+    {file = "requests-mock-1.9.2.tar.gz", hash = "sha256:33296f228d8c5df11a7988b741325422480baddfdf5dd9318fd0eb40c3ed8595"},
+    {file = "requests_mock-1.9.2-py2.py3-none-any.whl", hash = "sha256:5c8ef0254c14a84744be146e9799dc13ebc4f6186058112d9aeed96b131b58e2"},
 ]
 requests-toolbelt = [
     {file = "requests-toolbelt-0.9.1.tar.gz", hash = "sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"},

--- a/real-main/pyproject.toml
+++ b/real-main/pyproject.toml
@@ -31,7 +31,7 @@ python = "^3.8"
 [tool.poetry.dev-dependencies]
 boto3 = "^1.11.9"
 pytest = "^6.2.3"
-requests-mock = "~1.8.0"
+requests-mock = "^1.9.2"
 cryptography = "^2.8"
 requests-aws4auth = "^0.9"
 pillow = "^7.2.0"


### PR DESCRIPTION
Over in requests-mock they fixed [their blocker bug](https://github.com/jamielennox/requests-mock/issues/170) overnight, so now we can remove the version pin and upgrade to the latest and greatest.