### PR TITLE
Updates to deployment docs, improve consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To deploy each serverless stack, run `yarn deploy` in that stack's root director
 
 ### AWS Credentials
 
-By default, serverless will use aws credentials stored in the profile with name `real-{stage}` (ie: `real-dev`, `real-staging`, or `real-production`). This behavior can be overridden by using the [`--aws-profile`](https://serverless.com/framework/docs/providers/aws/guide/credentials/#using-aws-profiles) option.
+If the aws `default` profile exists in your `~/.aws/credentials`, serverless will use it. Else, you can use the [`--aws-profile`](https://serverless.com/framework/docs/providers/aws/guide/credentials/#using-aws-profiles) option or explicitly set the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 
 Serverless expects the AWS credentials to have `AdministratorAccess` policy attached.
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ _Once per deployment_
 
 Please talk to the backend team lead to get access to these stacks.
 
+#### `bad-words`
+
+_Required, must be deployed before `real-main`_
+
+#### `promo-codes`
+
+_Required, must be deployed before `real-main`_
+
 #### `themes`
 
 _Required, must be deployed before `real-main`_

--- a/real-auth/serverless.yml
+++ b/real-auth/serverless.yml
@@ -3,7 +3,6 @@ frameworkVersion: '>=1.0.0 <2.0.0'
 
 provider:
   name: aws
-  profile: real-${self:provider.stage}
   stackName: real-${self:provider.stage}-auth
   stage: ${opt:stage, 'dev'}
   runtime: python3.8

--- a/real-cloudfront/serverless.yml
+++ b/real-cloudfront/serverless.yml
@@ -8,7 +8,6 @@ frameworkVersion: '>=1.0.0 <2.0.0'
 
 provider:
   name: aws
-  profile: real-${self:provider.stage}
   stackName: real-${self:provider.stage}-cloudfront
   stage: ${opt:stage, 'dev'}
   runtime: python3.7

--- a/real-lambda-layers/serverless.yml
+++ b/real-lambda-layers/serverless.yml
@@ -12,7 +12,6 @@ frameworkVersion: '>=1.0.0 <2.0.0'
 
 provider:
   name: aws
-  profile: real-${self:provider.stage}
   stackName: real-${self:provider.stage}-lambda-layers
   stage: ${opt:stage, 'dev'}
   runtime: python3.8


### PR DESCRIPTION
In this PR:

- docs updates to reference the `bad-words` and `promo-codes` stacks
- docs updates for the removal of the `profile` from `real-main/serverless.yml`
- remove `profile` from the other `serverless.yml` files as well for consistency