### PR TITLE
More features for posts and coin tickers

### DIFF
--- a/integration-testing/schema/queries.js
+++ b/integration-testing/schema/queries.js
@@ -350,6 +350,27 @@ export const similarPosts = gql`
   }
 `
 
+export const postsByPaymentTicker = gql`
+  query PostsByPaymentTicker(
+    $paymentTicker: String!
+    $paymentTickerRequiredToView: Boolean
+    $limit: Int
+    $nextToken: String
+  ) {
+    posts: postsByPaymentTicker(
+      paymentTicker: $paymentTicker
+      paymentTickerRequiredToView: $paymentTickerRequiredToView
+      limit: $limit
+      nextToken: $nextToken
+    ) {
+      items {
+        postId
+      }
+      nextToken
+    }
+  }
+`
+
 export const searchKeywords = gql`
   query SearchKeywords($keyword: String!) {
     searchKeywords(keyword: $keyword)

--- a/integration-testing/tests/posts/by-payment-ticker.sequential.test.js
+++ b/integration-testing/tests/posts/by-payment-ticker.sequential.test.js
@@ -1,0 +1,42 @@
+import {v4 as uuidv4} from 'uuid'
+
+import {cognito, eventually, generateRandomJpeg} from '../../utils'
+import {mutations, queries} from '../../schema'
+
+const imageData = new Buffer.from(generateRandomJpeg(8, 8)).toString('base64')
+const loginCache = new cognito.AppSyncLoginCache()
+
+beforeAll(async () => {
+  loginCache.addCleanLogin(await cognito.getAppSyncLogin())
+})
+afterAll(async () => {
+  await loginCache.reset()
+})
+
+describe('Query.postsByPaymentTicker', () => {
+  let client1
+  const postIdWithDefaultTicker = uuidv4()
+
+  beforeAll(async () => {
+    await loginCache.clean()
+    ;({client: client1} = await loginCache.getCleanLogin())
+
+    await client1.mutate({mutation: mutations.addPost, variables: {postId: postIdWithDefaultTicker, imageData}})
+    await client1.mutate({
+      mutation: mutations.addPost,
+      variables: {postId: uuidv4(), imageData, paymentTicker: uuidv4()},
+    })
+  })
+
+  describe('when querying for the default REAL paymentTicker', () => {
+    it('returns all posts that were created without a paymentTicker', async () => {
+      await eventually(async () => {
+        const {data} = await client1.query({
+          query: queries.postsByPaymentTicker,
+          variables: {paymentTicker: 'REAL'},
+        })
+        expect(data).toMatchObject({posts: {items: [{postId: postIdWithDefaultTicker}], nextToken: null}})
+      })
+    })
+  })
+})

--- a/integration-testing/tests/posts/by-payment-ticker.test.js
+++ b/integration-testing/tests/posts/by-payment-ticker.test.js
@@ -27,18 +27,6 @@ describe('Query.postsByPaymentTicker', () => {
     await client1.mutate({mutation: mutations.addPost, variables: {postId: postIdWithDefaultTicker, imageData}})
   })
 
-  describe('when querying for the default REAL paymentTicker', () => {
-    it('returns all posts that were created without a paymentTicker', async () => {
-      await eventually(async () => {
-        const {data} = await client1.query({
-          query: queries.postsByPaymentTicker,
-          variables: {paymentTicker: 'REAL'},
-        })
-        expect(data).toMatchObject({posts: {items: [{postId: postIdWithDefaultTicker}], nextToken: null}})
-      })
-    })
-  })
-
   describe('when there are no posts with that paymentTicker', () => {
     it('returns no posts', async () => {
       const {data} = await client1.query({

--- a/integration-testing/tests/posts/by-payment-ticker.test.js
+++ b/integration-testing/tests/posts/by-payment-ticker.test.js
@@ -1,0 +1,136 @@
+import {v4 as uuidv4} from 'uuid'
+
+import {cognito, eventually, generateRandomJpeg} from '../../utils'
+import {mutations, queries} from '../../schema'
+
+const imageData = new Buffer.from(generateRandomJpeg(8, 8)).toString('base64')
+const loginCache = new cognito.AppSyncLoginCache()
+
+beforeAll(async () => {
+  loginCache.addCleanLogin(await cognito.getAppSyncLogin())
+  loginCache.addCleanLogin(await cognito.getAppSyncLogin())
+})
+afterAll(async () => {
+  await loginCache.reset()
+})
+
+describe('Query.postsByPaymentTicker', () => {
+  let client1, client2, userId2
+  const postIdWithDefaultTicker = uuidv4()
+
+  beforeAll(async () => {
+    await loginCache.clean()
+    ;({client: client1} = await loginCache.getCleanLogin())
+    ;({client: client2, userId: userId2} = await loginCache.getCleanLogin())
+
+    // add one post with the default paymentTicker
+    await client1.mutate({mutation: mutations.addPost, variables: {postId: postIdWithDefaultTicker, imageData}})
+  })
+
+  describe('when querying for the default REAL paymentTicker', () => {
+    it('returns all posts that were created without a paymentTicker', async () => {
+      await eventually(async () => {
+        const {data} = await client1.query({
+          query: queries.postsByPaymentTicker,
+          variables: {paymentTicker: 'REAL'},
+        })
+        expect(data).toMatchObject({posts: {items: [{postId: postIdWithDefaultTicker}], nextToken: null}})
+      })
+    })
+  })
+
+  describe('when there are no posts with that paymentTicker', () => {
+    it('returns no posts', async () => {
+      const {data} = await client1.query({
+        query: queries.postsByPaymentTicker,
+        variables: {paymentTicker: uuidv4()},
+      })
+      expect(data).toMatchObject({posts: {items: [], nextToken: null}})
+    })
+  })
+
+  describe('when there is one post with that paymentTicker', () => {
+    const paymentTicker = uuidv4()
+    const postId = uuidv4()
+
+    beforeAll(async () => {
+      await client1.mutate({mutation: mutations.addPost, variables: {postId, paymentTicker}})
+    })
+
+    it('returns one post', async () => {
+      await eventually(async () => {
+        const {data} = await client1.query({query: queries.postsByPaymentTicker, variables: {paymentTicker}})
+        expect(data).toMatchObject({posts: {items: [{postId}], nextToken: null}})
+      })
+    })
+  })
+
+  describe('when there are three posts with that paymentTicker', () => {
+    const paymentTicker = uuidv4()
+    const [postId1, postId2, postId3] = [uuidv4(), uuidv4(), uuidv4()]
+
+    beforeAll(async () => {
+      await client2.mutate({mutation: mutations.addPost, variables: {postId: postId1, paymentTicker}})
+      await client2.mutate({
+        mutation: mutations.addPost,
+        variables: {postId: postId2, paymentTicker, paymentTickerRequiredToView: true},
+      })
+      await client1.mutate({mutation: mutations.addPost, variables: {postId: postId3, paymentTicker}})
+    })
+
+    it('returns two posts, most recently created first', async () => {
+      await eventually(async () => {
+        const {data} = await client1.query({query: queries.postsByPaymentTicker, variables: {paymentTicker}})
+        expect(data).toMatchObject({
+          posts: {items: [{postId: postId3}, {postId: postId2}, {postId: postId1}], nextToken: null},
+        })
+      })
+    })
+
+    describe('when using the limit parameter', () => {
+      let nextToken
+
+      it('limits the posts returned', async () => {
+        const {data} = await client1.query({
+          query: queries.postsByPaymentTicker,
+          variables: {paymentTicker, limit: 1},
+        })
+        expect(data).toMatchObject({posts: {items: [{postId: postId3}], nextToken: expect.anything()}})
+        nextToken = data.posts.nextToken
+      })
+
+      it('paginates the posts returned', async () => {
+        const {data} = await client1.query({
+          query: queries.postsByPaymentTicker,
+          variables: {paymentTicker, nextToken},
+        })
+        expect(data).toMatchObject({posts: {items: [{postId: postId2}, {postId: postId1}], nextToken: null}})
+      })
+    })
+
+    describe('when using the paymentRequiredToView parameter', () => {
+      it('filters out posts that dont have paymentRequiredToView set from the result', async () => {
+        const {data} = await client1.query({
+          query: queries.postsByPaymentTicker,
+          variables: {paymentTicker, paymentTickerRequiredToView: true},
+        })
+        expect(data).toMatchObject({posts: {items: [{postId: postId2}], nextToken: null}})
+      })
+    })
+
+    describe('when the user has been blocked by one of the post owners', () => {
+      beforeAll(async () => {
+        await client1.mutate({mutation: mutations.blockUser, variables: {userId: userId2}})
+      })
+
+      afterAll(async () => {
+        await client1.mutate({mutation: mutations.unblockUser, variables: {userId: userId2}})
+      })
+
+      it('filters out the blockers users posts from the result', async () => {
+        const {data} = await client2.query({query: queries.postsByPaymentTicker, variables: {paymentTicker}})
+        expect(data).toMatchObject({posts: {items: [{postId: postId2}, {postId: postId1}], nextToken: null}})
+      })
+    })
+  })
+})

--- a/integration-testing/tests/posts/filter-by-payment-ticker.test.js
+++ b/integration-testing/tests/posts/filter-by-payment-ticker.test.js
@@ -1,0 +1,69 @@
+import {v4 as uuidv4} from 'uuid'
+
+import {cognito, eventually} from '../../utils'
+import {mutations, queries} from '../../schema'
+
+const loginCache = new cognito.AppSyncLoginCache()
+
+beforeAll(async () => {
+  loginCache.addCleanLogin(await cognito.getAppSyncLogin())
+  loginCache.addCleanLogin(await cognito.getAppSyncLogin())
+})
+afterAll(async () => {
+  await loginCache.reset()
+})
+
+/**
+ * This test depends on the real transactions client to be disabled,
+ * an thus mocking the response of get_user_tickers() to be a list of
+ * two tickers: REAL and the caller's user id.
+ */
+describe('Queries of paginated posts, when some have paymentTicker and paymentTickerRequiredToView set', () => {
+  let client1, client2
+  let userId1, userId2
+  const postType = 'TEXT_ONLY'
+  const text = 'lore ipsum'
+  const paymentTickerRequiredToView = true
+  const [postId1, postId2, postId3, postId4] = [uuidv4(), uuidv4(), uuidv4(), uuidv4()]
+
+  beforeAll(async () => {
+    await loginCache.clean()
+    ;({client: client1, userId: userId1} = await loginCache.getCleanLogin())
+    ;({client: client2, userId: userId2} = await loginCache.getCleanLogin())
+
+    await client1.mutate({
+      mutation: mutations.addPost,
+      variables: {postId: postId1, postType, text, paymentTicker: uuidv4()},
+    })
+    await client1.mutate({
+      mutation: mutations.addPost,
+      variables: {postId: postId2, postType, text, paymentTicker: uuidv4(), paymentTickerRequiredToView},
+    })
+    await client1.mutate({
+      mutation: mutations.addPost,
+      variables: {postId: postId3, postType, text, paymentTickerRequiredToView},
+    })
+    await client1.mutate({
+      mutation: mutations.addPost,
+      variables: {postId: postId4, postType, text, paymentTicker: userId2, paymentTickerRequiredToView},
+    })
+  })
+
+  it('do not filter posts when the post owner looks at them', async () => {
+    await eventually(async () => {
+      const {data} = await client1.query({query: queries.userPosts, variables: {userId: userId1}})
+      expect(data).toMatchObject({
+        user: {posts: {items: [{postId: postId4}, {postId: postId3}, {postId: postId2}, {postId: postId1}]}},
+      })
+    })
+  })
+
+  it('filter posts when a different user looks at them', async () => {
+    await eventually(async () => {
+      const {data} = await client2.query({query: queries.userPosts, variables: {userId: userId1}})
+      expect(data).toMatchObject({
+        user: {posts: {items: [{postId: postId4}, {postId: postId3}, {postId: postId1}]}},
+      })
+    })
+  })
+})

--- a/integration-testing/tests/posts/payment.test.js
+++ b/integration-testing/tests/posts/payment.test.js
@@ -233,7 +233,7 @@ describe('Post.paymentTickerRequiredToView', () => {
     })
   })
 
-  test('Add post without setting paymentTicker', async () => {
+  test('Add post without setting paymentTickerRequiredToView', async () => {
     const postId = uuidv4()
     const paymentTickerRequiredToViewDefault = false
     await client.mutate({mutation: mutations.addPost, variables: {postId, imageData}})
@@ -245,7 +245,7 @@ describe('Post.paymentTickerRequiredToView', () => {
     })
   })
 
-  test('Add post with paymentTicker set', async () => {
+  test('Add post with paymentTickerRequiredToView set', async () => {
     const postId = uuidv4()
     const paymentTickerRequiredToView = true
     await client.mutate({

--- a/real-main/app/clients/real_transactions.py
+++ b/real-main/app/clients/real_transactions.py
@@ -68,3 +68,12 @@ class RealTransactionsClient:
             'ticker': ticker,
         }
         self.session.post(url, auth=self.auth, data=json.dumps(data, cls=DecimalAsStringJsonEncoder))
+
+    def get_user_tickers(self, user_id):
+        "Return a list coin tickers the user is holding in their wallet"
+        if self.disabled:
+            return ['REAL', user_id]
+        url = f'{self.api_root}/wallet'
+        data = {'user_uuid': user_id}
+        resp = self.session.post(url, auth=self.auth, data=json.dumps(data))
+        return list(resp.json().get('body', {}).get('wallet', {}).keys())

--- a/real-main/app/handlers/appsync/dispatch.py
+++ b/real-main/app/handlers/appsync/dispatch.py
@@ -28,10 +28,14 @@ def get_client_details(event):
 
 def get_gql_details(event):
     return {
-        'arguments': event.get('arguments') or {},
-        'field': event['info']['parentTypeName'] + '.' + event['info']['fieldName'],
-        'source': event.get('source') or {},
-        'callerUserId': (event.get('identity') or {}).get('cognitoIdentityId'),
+        'arguments': event.get('arguments', {}),
+        'field': (
+            event.get('stash', {}).get('functionName')
+            or '.'.join([event['info']['parentTypeName'], event['info']['fieldName']])
+        ),
+        'source': event.get('source', {}),
+        'callerUserId': event.get('identity', {}).get('cognitoIdentityId'),
+        'prev': event.get('prev', {}),
     }
 
 
@@ -65,6 +69,7 @@ def dispatch(event, context):
             gql['callerUserId'],
             gql['arguments'],
             source=gql['source'],
+            prev=gql['prev'],
             context=context,
             event=event,
             client=client,

--- a/real-main/app/handlers/appsync/handlers.py
+++ b/real-main/app/handlers/appsync/handlers.py
@@ -60,6 +60,7 @@ clients = {
     'pinpoint': clients.PinpointClient(),
     'post_verification': clients.PostVerificationClient(secrets_manager_client.get_post_verification_api_creds),
     'real_dating': clients.RealDatingClient(),
+    'real_transactions': clients.RealTransactionsClient(),
     'redeem_promotion': clients.RedeemPromotionClient(),
     's3_uploads': clients.S3Client(S3_UPLOADS_BUCKET),
     's3_placeholder_photos': clients.S3Client(S3_PLACEHOLDER_PHOTOS_BUCKET),
@@ -1656,3 +1657,15 @@ def swiped_right_users(caller_user, arguments, **kwargs):
             response.append(user.serialize(caller_user.id))
 
     return response
+
+
+@routes.register('Posts.filterBy.paymentTickerRequiredToView')
+def posts_filter_by_payment_ticker_required_to_view(caller_user_id, arguments, prev=None, **kwargs):
+    posts = prev['result']
+
+    try:
+        filtered_posts = post_manager.filter_by_payment_ticker_required_to_view(caller_user_id, posts)
+    except PostException as err:
+        raise ClientException(str(err)) from err
+
+    return filtered_posts

--- a/real-main/app_tests/clients/test_real_transactions.py
+++ b/real-main/app_tests/clients/test_real_transactions.py
@@ -18,6 +18,7 @@ api_region = 'the-region'
 endpoint_urls = {
     'pay_for_ad_view': f'https://{api_host}/{api_stage}/pay_user_for_advertisement',
     'pay_for_post_view': f'https://{api_host}/{api_stage}/pay_for_post_view',
+    'get_user_tickers': f'https://{api_host}/{api_stage}/wallet',
 }
 
 
@@ -142,3 +143,15 @@ def test_handles_success_response(client, mock_env_aws_auth, func_name, ticker):
     with requests_mock.Mocker() as m:
         m.post(url, status_code=success_status, json=success_response)
         target(*args)  # silently succeeds
+
+
+@pytest.mark.parametrize('tickers', [[], ['foo', 'bar']])
+def test_get_user_tickers(client, mock_env_aws_auth, tickers):
+    url = endpoint_urls['get_user_tickers']
+    success_status = 200
+    success_response = {"message": "ok", "status": 0, "body": {"wallet": {t: {} for t in tickers}}}
+    user_id = str(uuid4())
+    with requests_mock.Mocker() as m:
+        m.post(url, status_code=success_status, json=success_response)
+        result = client.get_user_tickers(user_id)
+    assert result == tickers

--- a/real-main/app_tests/handlers/appsync/test_dispatch.py
+++ b/real-main/app_tests/handlers/appsync/test_dispatch.py
@@ -36,6 +36,22 @@ def api_key_authed_event():
 
 
 @pytest.fixture
+def function_event():
+    yield {
+        'info': {
+            'parentTypeName': 'Something',
+            'fieldName': 'else',
+        },
+        'arguments': ['arg1', 'arg2'],
+        'identity': {},
+        'source': {'anotherField': 42},
+        'request': {'headers': {}},
+        'stash': {'functionName': 'Type.field'},
+        'prev': {'foo': 'bar'},
+    }
+
+
+@pytest.fixture
 def setup_one_route():
     routes.clear()
 
@@ -60,6 +76,7 @@ def test_basic_success(setup_one_route, cognito_authed_event):
                 'context': {},
                 'client': {'version': '1.2.3(456)'},
                 'event': cognito_authed_event,
+                'prev': {},
             },
         },
     }
@@ -76,6 +93,7 @@ def test_no_source(setup_one_route, cognito_authed_event):
                 'context': {},
                 'client': {'version': '1.2.3(456)'},
                 'event': cognito_authed_event,
+                'prev': {},
             },
         },
     }
@@ -91,6 +109,7 @@ def test_api_key_authenticated(setup_one_route, api_key_authed_event):
                 'context': {},
                 'client': {},
                 'event': api_key_authed_event,
+                'prev': {},
             },
         },
     }
@@ -106,6 +125,23 @@ def test_context_passed(setup_one_route, api_key_authed_event):
                 'context': {'foo': 'bar'},
                 'client': {},
                 'event': api_key_authed_event,
+                'prev': {},
+            },
+        },
+    }
+
+
+def test_from_function(setup_one_route, function_event):
+    assert dispatch(function_event, {'foo': 'bar'}) == {
+        'data': {
+            'caller_user_id': None,
+            'arguments': ['arg1', 'arg2'],
+            'kwargs': {
+                'source': {'anotherField': 42},
+                'context': {'foo': 'bar'},
+                'client': {},
+                'event': function_event,
+                'prev': {'foo': 'bar'},
             },
         },
     }

--- a/real-main/mapping-templates/Posts.filterBy.paymentTickerRequiredToView.request.vtl
+++ b/real-main/mapping-templates/Posts.filterBy.paymentTickerRequiredToView.request.vtl
@@ -1,0 +1,21 @@
+#set ($prevPosts = $ctx.prev.result)
+#set ($callerUserId = $ctx.identity.cognitoIdentityId)
+
+#set ($needsFiltering = false)
+#foreach ($post in $prevPosts)
+  #if ($post.paymentTickerRequiredToView and $post.postedByUserId != $callerUserId)
+    #set ($needsFiltering = true)
+    #break
+  #end
+#end
+
+#if (!$needsFiltering)
+  #return ($prevPosts)
+#end
+
+$util.qr($ctx.stash.put('functionName', 'Posts.filterBy.paymentTickerRequiredToView'))
+{
+  "version": "2018-05-29",
+  "operation": "Invoke",
+  "payload": $util.toJson($ctx)
+}

--- a/real-main/mapping-templates/Query.postsByPaymentTicker.request.vtl
+++ b/real-main/mapping-templates/Query.postsByPaymentTicker.request.vtl
@@ -1,0 +1,25 @@
+#if ($ctx.args.limit < 1 or $ctx.args.limit > 100)
+  $util.error('ClientError: Limit cannot be less than 1 or greater than 100', 'ClientError')
+#end
+#set ($limit = $util.defaultIfNull($ctx.args.limit, 20))
+
+#set ($nextToken = $ctx.args.nextToken)
+#set ($paymentTicker = $ctx.args.paymentTicker)
+#set ($paymentTickerRequiredToView = $ctx.args.paymentTickerRequiredToView)
+
+{
+  "version": "2018-05-29",
+  "operation": "Query",
+  "query": {
+    "expression": "gsiA5PartitionKey = :pk",
+    "expressionValues": {":pk": {"S": "postPaymentTicker/$paymentTicker"}}
+  },
+  "index": "GSI-A5",
+  "scanIndexForward": false,
+  "limit": $limit
+  #if ($nextToken), "nextToken": "$nextToken"#end
+  #if ($paymentTickerRequiredToView), "filter": {
+    "expression": "paymentTickerRequiredToView = :ptrtv",
+    "expressionValues": {":ptrtv": {"BOOL": true}}
+  }#end
+}

--- a/real-main/schema.graphql
+++ b/real-main/schema.graphql
@@ -66,6 +66,13 @@ type Query {
   # Globally trending posts
   trendingPosts(limit: Int, nextToken: String): PaginatedPosts!
 
+  postsByPaymentTicker(
+    paymentTicker: String!,
+    paymentTickerRequiredToView: Boolean,
+    limit: Int,
+    nextToken: String,
+  ): PaginatedPosts!
+
   # Search keywords for autocomplete
   searchKeywords(keyword: String!): [String]!
 

--- a/real-main/serverless.yml
+++ b/real-main/serverless.yml
@@ -264,6 +264,7 @@ custom:
         functions:
           - Posts.batchGet
           - Posts.filterBy.adStatus
+          - Posts.filterBy.paymentTickerRequiredToView
           - PaginatedPosts.items.applyFilters
           - Users.beginPipeline
           - Users.batchGet
@@ -335,6 +336,10 @@ custom:
 
       - dataSource: DynamodbDataSource
         name: Posts.filterBy.adStatus
+
+      - dataSource: LambdaDataSource
+        name: Posts.filterBy.paymentTickerRequiredToView
+        response: Lambda.response.vtl
 
       - dataSource: DynamodbDataSource
         name: PaginatedPosts.items.applyFilters

--- a/real-main/serverless/mapping-templates/query.yml
+++ b/real-main/serverless/mapping-templates/query.yml
@@ -61,6 +61,7 @@
   functions:
     - Posts.batchGet
     - Posts.filterBy.adStatus
+    - Posts.filterBy.paymentTickerRequiredToView
     - Users.beginPipeline
     - Users.batchGet
     - Users.batchGet.blockerStatus

--- a/real-main/serverless/mapping-templates/query.yml
+++ b/real-main/serverless/mapping-templates/query.yml
@@ -82,6 +82,17 @@
       - $context.args.nextToken
 
 - type: Query
+  field: postsByPaymentTicker
+  response: PassThru.response.vtl
+  dataSource: DynamodbDataSource
+  caching:
+    keys:
+      - $context.args.paymentTicker
+      - $context.args.paymentTickerRequiredToView
+      - $context.args.limit
+      - $context.args.nextToken
+
+- type: Query
   field: album
   request: Query.album/before.request.vtl
   response: Query.album/after.response.vtl


### PR DESCRIPTION
This PR:

- adds a GQL query to allow querying of all posts that are associated with a coin https://real-social.atlassian.net/browse/BE-182
- makes the `Post.paymentTicker` and `Post.paymentTickerRequriedToView` fields "live" in that if these are set, posts will be hidden from users that do not hold the `Post.paymentTicker` in their wallet.
  - this depends on https://github.com/real-social-media/transactions/pull/13
  - a user is still allowed to see their own posts, even if they don't hold the required ticket in their wallet

Note that it's ok to merge this before https://github.com/real-social-media/transactions/pull/13 since the real social backend [has the transactions service disabled](https://github.com/real-social-media/backend/blob/v2021-07-01/real-main/serverless.yml#L52) as there is still no production version of the transactions service, AFAIK.